### PR TITLE
Add expectExceptionMessage to assert message

### DIFF
--- a/tests/src/DisallowFloatInMethodSignatureRuleTest.php
+++ b/tests/src/DisallowFloatInMethodSignatureRuleTest.php
@@ -69,6 +69,7 @@ final class DisallowFloatInMethodSignatureRuleTest extends RuleTestCase
             ->willReturn(false);
 
         $this->expectException(ShouldNotHappenException::class);
+        $this->expectExceptionMessage('Internal error.');
 
         $rule->processNode($node, $scope);
     }

--- a/tests/src/DisallowFloatPropertyTypeRuleTest.php
+++ b/tests/src/DisallowFloatPropertyTypeRuleTest.php
@@ -47,6 +47,7 @@ final class DisallowFloatPropertyTypeRuleTest extends RuleTestCase
             ->willReturn(false);
 
         $this->expectException(ShouldNotHappenException::class);
+        $this->expectExceptionMessage('Internal error.');
 
         $rule->processNode($node, $scope);
     }


### PR DESCRIPTION
# Changed log
- Add the `expectExceptionMessage` to assert the expected exception message is same as result.