### PR TITLE
Handle "never" type as non float

### DIFF
--- a/src/FloatTypeHelper.php
+++ b/src/FloatTypeHelper.php
@@ -6,6 +6,7 @@ namespace Roave\PHPStan\Rules\Floats;
 
 use PHPStan\Type\FloatType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 
 /** @internal class is only for internal tooling use: do not import it in your own projects */
@@ -14,6 +15,10 @@ final class FloatTypeHelper
     public static function isFloat(Type $type): bool
     {
         if ($type instanceof MixedType) {
+            return false;
+        }
+
+        if ($type instanceof NeverType) {
             return false;
         }
 

--- a/tests/asset/function.php
+++ b/tests/asset/function.php
@@ -22,3 +22,11 @@ function doBar(): string
 {
 
 }
+
+/**
+ * @return never
+ */
+function withNever()
+{
+    throw new \RuntimeException();
+}

--- a/tests/asset/method.php
+++ b/tests/asset/method.php
@@ -26,4 +26,11 @@ class Foo
 
     }
 
+    /**
+     * @return never
+     */
+    public function withNever()
+    {
+        throw new \RuntimeException();
+    }
 }


### PR DESCRIPTION
As `MixedType`, `NeverType` implements `CompoundType` witch always returns yes on `isSubTypeOf()` calls. It forbids the use of `never` native PHP type (or as annotation) with this extension.