### PR TITLE
Remove services section from `phpstan.neon.dist`

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,11 +10,3 @@ parameters:
 		- %currentWorkingDirectory%/tests/src
 	level: 8
 
-services:
-	scopeIsInClass:
-		class: PHPStan\Internal\ScopeIsInClassTypeSpecifyingExtension
-		arguments:
-			isInMethodName: isInClass
-			removeNullMethodName: getClassReflection
-		tags:
-			- phpstan.typeSpecifier.methodTypeSpecifyingExtension


### PR DESCRIPTION
Internal ScopeIsInClassTypeSpecifyingExtension class is already removed.
https://github.com/phpstan/phpstan-src/commit/ace76ce2be8b156cbd6a6b42f4d8505773a8488d

fixes #104 

@ondrejmirtes Could you confirm this?