### PR TITLE
Add phpstan-extension type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "roave/no-floaters",
+    "type": "phpstan-extension",
     "description": "PHPStan Rules to Disallow Float proliferation in contexts where IEEE-754 rounding errors are not acceptable",
     "license": [
         "MIT"


### PR DESCRIPTION
This type is  useful for search,
https://packagist.org/?type=phpstan-extension is linked from
https://phpstan.org/user-guide/extension-library .